### PR TITLE
needless borrow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@ impl<T> TrackedObject<T> {
     where
         F: FnOnce(&T) -> T,
     {
-        let t = f(&self);
+        let t = f(self);
         self.inner.census.track(t)
     }
 }


### PR DESCRIPTION
Fix cargo clippy warning
#[warn(clippy::needless_borrow)]